### PR TITLE
Embed Tiny Core Linux VM in browser page

### DIFF
--- a/tclinvbrowser.html
+++ b/tclinvbrowser.html
@@ -3,183 +3,213 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TheCurity</title>
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap">
+    <title>Tiny Core Linux in your Browser</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
     <style>
-    body {
-      font-family: 'Roboto', sans-serif;
-      background: linear-gradient(135deg, #001f3f, #004080, #0074D9);
-      color: #ffffff;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
+        :root {
+            color-scheme: dark;
+            --bg: radial-gradient(circle at top, #0b1d3a, #020817 60%);
+            --accent: #58b6ff;
+            --panel: rgba(5, 14, 31, 0.85);
+            --border: rgba(88, 182, 255, 0.35);
+            --text: #e4f1ff;
+        }
 
-    header {
-      background-color: rgba(0, 0, 0, 0.7);
-      color: white;
-      padding: 2rem;
-      text-align: center;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
-    }
+        * {
+            box-sizing: border-box;
+        }
 
-    header h1 {
-      font-size: 3rem;
-      text-transform: uppercase;
-      letter-spacing: 0.3rem;
-      font-family: 'MedievalSharp', cursive;
-      animation: glow 1.5s infinite alternate;
-    }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            font-family: 'JetBrains Mono', monospace;
+            background: var(--bg);
+            color: var(--text);
+        }
 
-    @keyframes glow {
-      from { text-shadow: 0 0 15px #00aaff, 0 0 30px #0074D9, 0 0 45px #0074D9; }
-      to   { text-shadow: 0 0 25px #00ffff, 0 0 40px #0074D9, 0 0 55px #004080; }
-    }
+        header {
+            padding: 2.5rem 1rem 1.5rem;
+            text-align: center;
+        }
 
-    main, .page {
-      flex: 1;
-      padding: 2rem 3rem;
-      background: rgba(0, 0, 0, 0.85);
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.6);
-      margin: 2rem;
-      border-radius: 12px;
-      display: none;
-      opacity: 0;
-      transform: translateY(20px);
-      transition: opacity 0.6s ease, transform 0.6s ease;
-    }
+        h1 {
+            margin: 0;
+            font-size: clamp(2rem, 4vw, 3rem);
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--accent);
+            text-shadow: 0 0 25px rgba(88, 182, 255, 0.55);
+        }
 
-    main.active, .page.active {
-      display: block;
-      opacity: 1;
-      transform: translateY(0);
-    }
+        main {
+            flex: 1;
+            display: grid;
+            place-items: center;
+            padding: 0 1.5rem 3rem;
+        }
 
-    h2 {
-      font-size: 2rem;
-      margin-bottom: 1rem;
-      border-bottom: 2px solid #00aaff;
-      padding-bottom: 0.5rem;
-    }
+        .terminal-card {
+            width: min(100%, 1080px);
+            backdrop-filter: blur(16px);
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            padding: 2rem;
+            box-shadow: 0 35px 90px rgba(6, 20, 48, 0.65);
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
 
-    p { line-height: 1.6; margin-bottom: 1rem; }
+        .screen-wrapper {
+            position: relative;
+            border: 2px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
+            background: #000;
+            min-height: 420px;
+            display: flex;
+        }
 
-    .buttons {
-      position: fixed;
-      top: 50%;
-      right: 0;
-      transform: translateY(-50%);
-      display: flex;
-      flex-direction: column;
-    }
+        #screen {
+            width: 100%;
+            min-height: 420px;
+        }
 
-    .buttons button {
-      background: rgba(255, 255, 255, 0.15);
-      border: 2px solid #00aaff;
-      color: #ffffff;
-      padding: 1rem 1.5rem;
-      margin: 0.5rem 0;
-      font-size: 1rem;
-      cursor: pointer;
-      transition: background 0.3s, transform 0.3s, border-color 0.3s;
-      border-radius: 8px;
-    }
+        .status-bar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: center;
+            justify-content: space-between;
+            font-size: 0.95rem;
+            color: rgba(228, 241, 255, 0.75);
+        }
 
-    .buttons button:hover {
-      background: rgba(255, 255, 255, 0.3);
-      transform: translateX(-12px);
-      border-color: #00ffff;
-    }
+        button {
+            font: inherit;
+            padding: 0.65rem 1.25rem;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: var(--text);
+            cursor: pointer;
+            transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+        }
 
-    footer {
-      background-color: rgba(0, 0, 0, 0.7);
-      color: white;
-      text-align: center;
-      padding: 2rem;
-      box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.5);
-    }
+        button:hover {
+            transform: translateY(-2px);
+            border-color: var(--accent);
+            box-shadow: 0 0 18px rgba(88, 182, 255, 0.35);
+        }
 
-    .social-icons a {
-      color: white;
-      margin: 0 0.5rem;
-      text-decoration: none;
-      font-size: 1.5rem;
-      transition: transform 0.3s, color 0.3s;
-    }
+        .instructions {
+            margin: 0;
+            line-height: 1.6;
+        }
 
-    .social-icons a:hover {
-      color: #00aaff;
-      transform: scale(1.3);
-    }
+        footer {
+            padding: 1.75rem 1rem;
+            text-align: center;
+            font-size: 0.9rem;
+            color: rgba(228, 241, 255, 0.6);
+        }
+
+        @media (max-width: 720px) {
+            .terminal-card {
+                padding: 1.5rem;
+            }
+
+            .status-bar {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        }
     </style>
 </head>
-<body onload="openPage('home')">
+<body>
     <header>
-        <h1>TheCurity</h1>
+        <h1>Tiny Core Linux in Your Browser</h1>
     </header>
-
-    <main id="home" class="active">
-        <h2>Welcome</h2>
-        <p>Welcome to TheCurity, where cutting-edge AI meets cybersecurity excellence. Our solutions harness machine learning to proactively secure your infrastructure and streamline threat management.</p>
+    <main>
+        <section class="terminal-card">
+            <p class="instructions">
+                You're about to boot a real Tiny Core Linux session powered by the open source <code>v86</code> emulator. Give it a few
+                moments to start – the ISO is streamed directly inside your browser. Click inside the window to capture your keyboard
+                and press <kbd>Ctrl</kbd>+<kbd>Alt</kbd> to release.
+            </p>
+            <div class="screen-wrapper">
+                <div id="screen"></div>
+            </div>
+            <div class="status-bar">
+                <div id="status">Loading emulator …</div>
+                <div>
+                    <button id="restart">Restart VM</button>
+                </div>
+            </div>
+        </section>
     </main>
-
-    <section id="page1" class="page">
-        <h2>Threat Intelligence</h2>
-        <p>Leverage real-time threat intelligence feeds and AI-powered analysis to identify emerging vulnerabilities and malicious actors before they strike. Our platform correlates firewall logs with global threat databases for actionable insights.</p>
-        <ul>
-            <li>Automated log enrichment & contextualization</li>
-            <li>Dynamic risk scoring & prioritization</li>
-            <li>Customizable intelligence dashboards</li>
-        </ul>
-    </section>
-
-    <section id="page2" class="page">
-        <h2>Incident Response</h2>
-        <p>Accelerate your incident response with automated alert triage and prescriptive playbooks. Our AI-driven system reduces noise, surfaces critical events, and suggests remediation steps to mitigate breaches swiftly.</p>
-        <ul>
-            <li>Smart alert aggregation & deduplication</li>
-            <li>Guided remediation workflows</li>
-            <li>Post-incident reporting & analytics</li>
-        </ul>
-    </section>
-
-    <section id="page3" class="page">
-        <h2>Compliance Dashboard</h2>
-        <p>Stay audit-ready with comprehensive compliance reporting. Monitor firewall policy adherence, generate detailed logs, and ensure alignment with standards like ISO 27001, GDPR, and HIPAA at a glance.</p>
-        <ul>
-            <li>Automated compliance checks</li>
-            <li>Custom report scheduling</li>
-            <li>Interactive audit trails</li>
-        </ul>
-    </section>
-
-    <div class="buttons">
-        <button onclick="openPage('home')">Home</button>
-        <button onclick="openPage('page1')">Threat Intelligence</button>
-        <button onclick="openPage('page2')">Incident Response</button>
-        <button onclick="openPage('page3')">Compliance Dashboard</button>
-    </div>
-
     <footer>
-        <h2>Contact Us</h2>
-        <div class="social-icons">
-            <a href="https://facebook.com" target="_blank"><i class="fab fa-facebook"></i></a>
-            <a href="https://twitter.com" target="_blank"><i class="fab fa-twitter"></i></a>
-            <a href="https://instagram.com" target="_blank"><i class="fab fa-instagram"></i></a>
-            <a href="https://linkedin.com" target="_blank"><i class="fab fa-linkedin"></i></a>
-        </div>
+        Tiny Core Linux © TinyCoreLinux.net — Emulator by copy.sh/v86
     </footer>
 
+    <script src="https://copy.sh/v86/build/v86.js"></script>
     <script>
-        function openPage(id) {
-            document.querySelectorAll('main, .page').forEach(el => el.classList.remove('active'));
-            document.getElementById(id).classList.add('active');
+        const statusEl = document.getElementById("status");
+        const restartBtn = document.getElementById("restart");
+        let emulator;
+
+        function bootTinyCore() {
+            statusEl.textContent = "Downloading Tiny Core Linux…";
+
+            emulator = new V86({
+                wasm_path: "https://copy.sh/v86/build/v86.wasm",
+                memory_size: 128 * 1024 * 1024,
+                vga_memory_size: 8 * 1024 * 1024,
+                screen_container: document.getElementById("screen"),
+                bios: { url: "https://copy.sh/v86/bios/seabios.bin" },
+                vga_bios: { url: "https://copy.sh/v86/bios/vgabios.bin" },
+                cdrom: { url: "https://copy.sh/v86/images/tinycorelinux12.iso" },
+                autostart: true,
+                disable_keyboard: false,
+                disable_mouse: false,
+                sound: {
+                    enabled: false,
+                },
+                onboot: () => {
+                    statusEl.textContent = "Tiny Core Linux is booting. Watch the console above.";
+                },
+            });
+
+            emulator.add_listener("emulator-ready", () => {
+                statusEl.textContent = "Ready! If the display is blank, press Enter inside the VM.";
+            });
+
+            emulator.add_listener("download-progress", (ev) => {
+                if (!ev.done) {
+                    const percent = Math.round((ev.loaded / ev.total) * 100);
+                    statusEl.textContent = `Downloading Tiny Core Linux… ${percent}%`;
+                }
+            });
+
+            emulator.add_listener("download-error", (ev) => {
+                statusEl.textContent = "Download failed. Please refresh to try again.";
+            });
         }
+
+        restartBtn.addEventListener("click", () => {
+            if (emulator) {
+                emulator.stop();
+                emulator = null;
+            }
+            bootTinyCore();
+        });
+
+        bootTinyCore();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the placeholder TheCurity marketing page with a dark-themed layout dedicated to Tiny Core Linux in the browser
- integrate the copy.sh v86 emulator so the page boots a real Tiny Core Linux ISO and shows live status updates
- add controls for restarting the virtual machine and guidance for capturing and releasing the keyboard

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfaef06f80832da69c29b9be1cfb85